### PR TITLE
Extract a common interface for scatter and line chart

### DIFF
--- a/src/GToolkit-Plotter/GtPlotterLineChart.class.st
+++ b/src/GToolkit-Plotter/GtPlotterLineChart.class.st
@@ -10,29 +10,7 @@ I draw line charts.
 "
 Class {
 	#name : #GtPlotterLineChart,
-	#superclass : #GtPlotterBuilder,
-	#instVars : [
-		'data',
-		'valueX',
-		'scaleX',
-		'scaleY',
-		'valueY',
-		'minX',
-		'maxX',
-		'minY',
-		'maxY',
-		'titleX',
-		'titleY',
-		'ticksX',
-		'ticksY',
-		'projectionXLabelElement',
-		'projectionXValues',
-		'projectionXLabelStyle',
-		'projectionXLineStyle',
-		'labelFormatX',
-		'labelFormatY',
-		'isAlreadyInitialized'
-	],
+	#superclass : #GtPlotterXYChart,
 	#category : #'GToolkit-Plotter-Builder - Line Chart'
 }
 
@@ -57,15 +35,6 @@ GtPlotterLineChart >> axisYStencil [
 		valuable: [ 
 			self newAxisYElement ];
 		scale: self scaleY
-]
-
-{ #category : #'api - instantiation' }
-GtPlotterLineChart >> contentStencil [
-	^ [ | anElement |
-	self initializeScales.
-	anElement := self newContentElement.
-	self styleChartElement: anElement.
-	anElement ] asStencil
 ]
 
 { #category : #'api - instantiation' }
@@ -106,11 +75,6 @@ GtPlotterLineChart >> create [
 	self styleChartElement: aContainer.
 	
 	^ aContainer
-]
-
-{ #category : #'api - data' }
-GtPlotterLineChart >> data [
-	^ data
 ]
 
 { #category : #initialization }
@@ -177,60 +141,6 @@ GtPlotterLineChart >> initializeScales [
 	scaleX domainFrom: aMinX to: aMaxX.
 	scaleY domainFrom: aMinY to: aMaxY.
 	
-]
-
-{ #category : #'api - axes' }
-GtPlotterLineChart >> labelFormatX: aBlock [
-	"Create a {{gtClass:BlText}}.
-	Block has one argument [ :aValue | ... ]"
-	labelFormatX := aBlock
-]
-
-{ #category : #'api - axes' }
-GtPlotterLineChart >> labelFormatY: aBlock [
-	"Create a {{gtClass:BlText}}.
-	Block has one argument [ :aValue | ... ]"
-	labelFormatY := aBlock
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> maxX [
-	^ maxX
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> maxX: anObject [
-	maxX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> maxY [
-	^ maxY
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> maxY: anObject [
-	maxY := anObject
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> minX [
-	^ minX
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> minX: anObject [
-	minX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> minY [
-	^ minY
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> minY: anObject [
-	minY := anObject
 ]
 
 { #category : #'instance creation' }
@@ -424,134 +334,6 @@ GtPlotterLineChart >> newNoDataElement [
 		constraintsDo: [ :c | 
 			c grid horizontal alignCenter.
 			c grid vertical alignCenter ]
-]
-
-{ #category : #'instance creation' }
-GtPlotterLineChart >> newProjectionXLabelsElement [
-	| anElement |
-	anElement := GtPlotterHorizontalValueProjectionsElement new
-		scale: self scaleX;
-		scaleData: valueX;
-		clipChildren: false;
-		constraintsDo: [ :c | c vertical fitContent ];
-		hideOverlapping;
-		values: (projectionXValues cull: self data).
-	
-	projectionXLabelElement ifNotNil: [ 
-		anElement valueElement: projectionXLabelElement ].
-
-	projectionXLabelStyle ifNotNil: [ 
-		anElement valueStyle: projectionXLabelStyle ].
-	
-	^ anElement
-]
-
-{ #category : #'instance creation' }
-GtPlotterLineChart >> newProjectionXLinesElement [
-	^ GtPlotterHorizontalValueProjectionsElement new
-		scale: self scaleX;
-		scaleData: valueX;
-		valueStyle: projectionXLineStyle;
-		values: (projectionXValues cull: self data)
-]
-
-{ #category : #'api - instantiation' }
-GtPlotterLineChart >> projectionLabelXStencil [
-	(self data size isZero or: [ projectionXValues isNil ])
-		ifTrue: [ ^ nil ].
-	self initializeScales.
-	^ BrValuableStencil new
-		valuable: [ self newProjectionXLabelsElement ]
-]
-
-{ #category : #'api - projections' }
-GtPlotterLineChart >> projectionXLabelElement: aBlock [
-	"Return projection label element. 
-	Block has one argument: [ :aGtPlotterSingleScaleContext | ... ]"
-	projectionXLabelElement := aBlock
-]
-
-{ #category : #'api - projections' }
-GtPlotterLineChart >> projectionXLabelStyle: aBlock [
-	"Style a label element. 
-	Block has one argument: [ :anElement | ... ]"
-	projectionXLabelStyle := aBlock
-]
-
-{ #category : #'api - projections' }
-GtPlotterLineChart >> projectionXLineStyle: aBlock [
-	"Style a label element. 
-	Block has one argument: [ :anElement :aGtPlotterScaleContext | ... ]"
-	projectionXLineStyle := aBlock
-]
-
-{ #category : #'api - projections' }
-GtPlotterLineChart >> projectionXValues: aBlock [
-	"Return projection values. 
-	Block has one argument: [ :aData | ... ]"
-	projectionXValues := aBlock
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> scaleX [
-	^ scaleX
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> scaleX: anObject [
-	scaleX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> scaleY [
-	^ scaleY
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> scaleY: anObject [
-	scaleY := anObject
-]
-
-{ #category : #'api - axes' }
-GtPlotterLineChart >> ticksX: aNumber [
-	"Define number of axis ticks"
-	ticksX := aNumber
-]
-
-{ #category : #'api - axes' }
-GtPlotterLineChart >> ticksY: aNumber [
-	"Define number of axis ticks"
-	ticksY := aNumber
-]
-
-{ #category : #'api - axes' }
-GtPlotterLineChart >> titleX: aString [
-	titleX := aString
-]
-
-{ #category : #'api - axes' }
-GtPlotterLineChart >> titleY: aString [
-	titleY := aString
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> valueX [
-	^ valueX
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> valueX: anObject [
-	valueX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> valueY [
-	^ valueY
-]
-
-{ #category : #accessing }
-GtPlotterLineChart >> valueY: anObject [
-	valueY := anObject
 ]
 
 { #category : #'api - data' }

--- a/src/GToolkit-Plotter/GtPlotterScatterChart.class.st
+++ b/src/GToolkit-Plotter/GtPlotterScatterChart.class.st
@@ -1,23 +1,7 @@
 Class {
 	#name : #GtPlotterScatterChart,
-	#superclass : #GtPlotterBuilder,
+	#superclass : #GtPlotterXYChart,
 	#instVars : [
-		'data',
-		'scaleX',
-		'scaleY',
-		'ticksX',
-		'ticksY',
-		'titleX',
-		'titleY',
-		'valueX',
-		'valueY',
-		'labelFormatX',
-		'labelFormatY',
-		'isAlreadyInitialized',
-		'minX',
-		'maxX',
-		'minY',
-		'maxY',
 		'dotElementStencil',
 		'valuesX',
 		'valuesY',
@@ -36,7 +20,7 @@ Class {
 
 { #category : #accessing }
 GtPlotterScatterChart >> axisXStencil [
-	^ axisXStencil
+	^ axisXStencil scatterChart: self
 ]
 
 { #category : #accessing }
@@ -46,7 +30,7 @@ GtPlotterScatterChart >> axisXStencil: aGtPlotterHorizontalTicksAndLabelStencil 
 
 { #category : #accessing }
 GtPlotterScatterChart >> axisYStencil [
-	^ axisYStencil
+	^ axisYStencil scatterChart: self
 ]
 
 { #category : #accessing }
@@ -94,11 +78,6 @@ GtPlotterScatterChart >> create [
 	self styleChartElement: aContainer.
 	
 	^ aContainer
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> data [
-	^ data
 ]
 
 { #category : #accessing }
@@ -268,66 +247,6 @@ GtPlotterScatterChart >> initializeScales [
 	
 ]
 
-{ #category : #accessing }
-GtPlotterScatterChart >> labelFormatX [
-	^ labelFormatX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> labelFormatX: anObject [
-	labelFormatX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> labelFormatY [
-	^ labelFormatY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> labelFormatY: anObject [
-	labelFormatY := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> maxX [
-	^ maxX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> maxX: anObject [
-	maxX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> maxY [
-	^ maxY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> maxY: anObject [
-	maxY := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> minX [
-	^ minX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> minX: anObject [
-	minX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> minY [
-	^ minY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> minY: anObject [
-	minY := anObject
-]
-
 { #category : #'api - instantiation' }
 GtPlotterScatterChart >> newAxisXElement [
 	^ axisXStencil
@@ -425,91 +344,9 @@ GtPlotterScatterChart >> pointEventHandler: aGtPlotterScatterFocusPointHandler [
 	pointEventHandler scatterChart: self.
 ]
 
-{ #category : #accessing }
-GtPlotterScatterChart >> scaleX [
-	^ scaleX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> scaleX: anObject [
-	scaleX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> scaleY [
-	^ scaleY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> scaleY: anObject [
-	scaleY := anObject
-]
-
 { #category : #'api - instantiation' }
 GtPlotterScatterChart >> scaledPoint: eachValue [
 	^ (scaleX map: (valueX value: eachValue)) @ (1 - (scaleY map: (valueY value: eachValue)))
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> ticksX [
-	^ ticksX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> ticksX: aNumber [
-	"Define number of axis ticks"
-	ticksX := aNumber
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> ticksY [
-	^ ticksY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> ticksY: aNumber [
-	"Define number of axis ticks"
-	ticksY := aNumber
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> titleX [
-	^ titleX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> titleX: aString [
-	titleX := aString
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> titleY [
-	^ titleY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> titleY: aString [
-	titleY := aString
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> valueX [
-	^ valueX
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> valueX: anObject [
-	valueX := anObject
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> valueY [
-	^ valueY
-]
-
-{ #category : #accessing }
-GtPlotterScatterChart >> valueY: anObject [
-	valueY := anObject
 ]
 
 { #category : #accessing }
@@ -557,8 +394,10 @@ GtPlotterScatterChart >> withProjectionAxis [
 
 { #category : #accessing }
 GtPlotterScatterChart >> withTicksAndLabelsAxis [
-	self axisYStencil: GtPlotterVerticalTicksAndLabelsAxisStencil new.
-	self axisXStencil: GtPlotterHorizontalTicksAndLabelsAxisStencil new.
+	self
+		axisYStencil: (GtPlotterVerticalTicksAndLabelsAxisStencil new scatterChart: self).
+	self
+		axisXStencil: (GtPlotterHorizontalTicksAndLabelsAxisStencil new scatterChart: self)
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-Plotter/GtPlotterXYChart.class.st
+++ b/src/GToolkit-Plotter/GtPlotterXYChart.class.st
@@ -1,0 +1,263 @@
+Class {
+	#name : #GtPlotterXYChart,
+	#superclass : #GtPlotterBuilder,
+	#instVars : [
+		'data',
+		'valueX',
+		'scaleX',
+		'scaleY',
+		'valueY',
+		'ticksX',
+		'ticksY',
+		'titleX',
+		'titleY',
+		'minX',
+		'maxX',
+		'minY',
+		'maxY',
+		'labelFormatX',
+		'labelFormatY',
+		'projectionXLabelElement',
+		'projectionXValues',
+		'projectionXLabelStyle',
+		'projectionXLineStyle',
+		'isAlreadyInitialized'
+	],
+	#category : #'GToolkit-Plotter-Builder - XY Chart'
+}
+
+{ #category : #'api - instantiation' }
+GtPlotterXYChart >> contentStencil [
+	^ [ | anElement |
+	self initializeScales.
+	anElement := self newContentElement.
+	self styleChartElement: anElement.
+	anElement ] asStencil
+]
+
+{ #category : #'api - data' }
+GtPlotterXYChart >> data [
+	^ data
+]
+
+{ #category : #initalization }
+GtPlotterXYChart >> initializeScales [
+	self subclassResponsibility
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> labelFormatX [
+	^ labelFormatX
+]
+
+{ #category : #'api - axes' }
+GtPlotterXYChart >> labelFormatX: aBlock [
+	"Create a {{gtClass:BlText}}.
+	Block has one argument [ :aValue | ... ]"
+	labelFormatX := aBlock
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> labelFormatY [
+	^ labelFormatY
+]
+
+{ #category : #'api - axes' }
+GtPlotterXYChart >> labelFormatY: aBlock [
+	"Create a {{gtClass:BlText}}.
+	Block has one argument [ :aValue | ... ]"
+	labelFormatY := aBlock
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> maxX [
+	^ maxX
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> maxX: anObject [
+	maxX := anObject
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> maxY [
+	^ maxY
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> maxY: anObject [
+	maxY := anObject
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> minX [
+	^ minX
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> minX: anObject [
+	minX := anObject
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> minY [
+	^ minY
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> minY: anObject [
+	minY := anObject
+]
+
+{ #category : #'instance creation' }
+GtPlotterXYChart >> newContentElement [
+	self subclassResponsibility
+]
+
+{ #category : #'instance creation' }
+GtPlotterXYChart >> newProjectionXLabelsElement [
+	| anElement |
+	anElement := GtPlotterHorizontalValueProjectionsElement new
+		scale: self scaleX;
+		scaleData: valueX;
+		clipChildren: false;
+		constraintsDo: [ :c | c vertical fitContent ];
+		hideOverlapping;
+		values: (projectionXValues cull: self data).
+	
+	projectionXLabelElement ifNotNil: [ 
+		anElement valueElement: projectionXLabelElement ].
+
+	projectionXLabelStyle ifNotNil: [ 
+		anElement valueStyle: projectionXLabelStyle ].
+	
+	^ anElement
+]
+
+{ #category : #'instance creation' }
+GtPlotterXYChart >> newProjectionXLinesElement [
+	^ GtPlotterHorizontalValueProjectionsElement new
+		scale: self scaleX;
+		scaleData: valueX;
+		valueStyle: projectionXLineStyle;
+		values: (projectionXValues cull: self data)
+]
+
+{ #category : #'api - instantiation' }
+GtPlotterXYChart >> projectionLabelXStencil [
+	(self data size isZero or: [ projectionXValues isNil ])
+		ifTrue: [ ^ nil ].
+	self initializeScales.
+	^ BrValuableStencil new
+		valuable: [ self newProjectionXLabelsElement ]
+]
+
+{ #category : #'api - projections' }
+GtPlotterXYChart >> projectionXLabelElement: aBlock [
+	"Return projection label element. 
+	Block has one argument: [ :aGtPlotterSingleScaleContext | ... ]"
+	projectionXLabelElement := aBlock
+]
+
+{ #category : #'api - projections' }
+GtPlotterXYChart >> projectionXLabelStyle: aBlock [
+	"Style a label element. 
+	Block has one argument: [ :anElement | ... ]"
+	projectionXLabelStyle := aBlock
+]
+
+{ #category : #'api - projections' }
+GtPlotterXYChart >> projectionXLineStyle: aBlock [
+	"Style a label element. 
+	Block has one argument: [ :anElement :aGtPlotterScaleContext | ... ]"
+	projectionXLineStyle := aBlock
+]
+
+{ #category : #'api - projections' }
+GtPlotterXYChart >> projectionXValues: aBlock [
+	"Return projection values. 
+	Block has one argument: [ :aData | ... ]"
+	projectionXValues := aBlock
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> scaleX [
+	^ scaleX
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> scaleX: anObject [
+	scaleX := anObject
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> scaleY [
+	^ scaleY
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> scaleY: anObject [
+	scaleY := anObject
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> ticksX [
+	^ ticksX
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> ticksX: aNumber [
+	"Define number of axis ticks"
+	ticksX := aNumber
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> ticksY [
+	^ ticksY
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> ticksY: aNumber [
+	"Define number of axis ticks"
+	ticksY := aNumber
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> titleX [
+	^ titleX
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> titleX: aString [
+	titleX := aString
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> titleY [
+	^ titleY
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> titleY: aString [
+	titleY := aString
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> valueX [
+	^ valueX
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> valueX: anObject [
+	valueX := anObject
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> valueY [
+	^ valueY
+]
+
+{ #category : #accessing }
+GtPlotterXYChart >> valueY: anObject [
+	valueY := anObject
+]


### PR DESCRIPTION
Hi all. 

I was trying to port to GT Plotter some charts from the Alexander Bergel book, Agile Artificial Intelligence in Pharo, originally made using Roassal. One of the first book examples use a composite chart that mixes a scatter plot with a line chart. I tried to reproduce that in GT, but I realized that  `GtPlotterCompositeChart` class only works with `GtPlotterLineChart` objects. 

Comparing `GtPlotterLineChart` class definition with `GtPlotterScatterChart` I could notice many common instance variables and methods (many of them, just accessors on these variables). Thus, I decided to extract the common behavior to a new super class that I called `GtPlotterXYChart`. 

Beyond the extraction of the common behavior, I need to do a small fix on methods `axisXStencil` and `axisYStencil` in the `GtPlotterScatterChart` class to guarantee the scatter chart object is correctly associated with the stencil. This was necessary since I got an error when the composite object `create` method executed. This is the small fix:

``` smalltalk
axisYStencil
	^ axisYStencil scatterChart: self
```

This is a fragment class diagram with the resultant classes related to the existent examples classes that test them. All original examples pass. 

![image](https://github.com/user-attachments/assets/b5d8d3ee-7aa1-4c6f-a327-8a4bab4d2676)

Here are the snippets to recreate the chart from the book (page 28, figure 1-12). I did it in a Lepiter page with three snippets:

Generate the scatter plot:

``` smalltalk
pairs := OrderedCollection new.

500 timesRepeat: [ 
	pairs add: (50 atRandom - 25) -> (50 atRandom - 25) ].
	
f := [ :x | (-2 * x) - 3 ].

data := GtPlotterDataGroup new values: pairs.
data := data background: [ :each | (each key > (f value: each value))
	ifTrue: [Color red ] 
	ifFalse: [Color blue ]].
	
dataGroup := GtPlotterDataGroup new values: data.
	
scatterChart := GtPlotterScatterChart new
	with: data;
	valueX: #key;
	scaleX: GtPlotterLinearScale new;
	labelFormatX: [ :x | x asString ];
	titleX: 'x';
	ticksX: 10;
	valueY: #value;
	scaleY: GtPlotterLinearScale new;
	titleY: 'y';
	ticksY: 4.
```

Generate the Line chart: 

``` smalltalk
pairs2 := (-15 to: 15 by:0.1)
			collect: [ :x | x -> (f value: x value) ].
			
data2 := GtPlotterDataGroup new values: pairs2.
data2 := data2 background: Color black.

lineChart2 := GtPlotterLineChart new
	with: data2;
	valueX: #key;
	scaleX: GtPlotterLinearScale new;
	labelFormatX: [ :x | x asString ];
	titleX: 'x';
	ticksX: 4;
	valueY: #value;
	scaleY: GtPlotterLinearScale new;
	titleY: 'y';
	ticksY: 4.
```

Generate the composite chart:

``` smalltalk
compositeChart := GtPlotterCompositeChart new.
compositeChart 
	addPlot: scatterChart;
	addPlot: lineChart2;
	yourself
```

This is the result chart: 

![image](https://github.com/user-attachments/assets/b47e1d94-1876-464f-afcf-bc729aa3cbc0)
